### PR TITLE
FIO-4816: added premium to formio-workers

### DIFF
--- a/workers/nunjucks.js
+++ b/workers/nunjucks.js
@@ -125,6 +125,14 @@ module.exports = (worker) => {
   const conditionallyInvisibleComponents = [];
   let unsetsEnabled = false;
 
+  try {
+    const {premium} = require('@formio/premium/dist/premium-server.min.js');
+
+    if (premium) {
+      Formio.Formio.use(premium);
+    }
+  } catch {} // Skip connecting premium components if this file does not exist
+
   return Formio.Formio.createForm(context.form, {
     server: true,
     noDefaults: true,


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-4816

## Description

**What changed?**

*Added premium so that formio-workers can recognize premium components and work with them*

**Why have you chosen this solution?**

*Because we need to get access to the premium. We get it from the formio server. If someone wants to use the formio-workers repository, they will not have access to premium. My correction was made purely for sending forms with components to the mail.*

## Dependencies

*This PR does not depends on the following PRs from other Form.io modules: ...*

## How has this PR been tested?

*I have not added automated tests to cover [all/the following] cases, including ...*

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above
