### PR TITLE
double the body request size limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const bodyParser = require('body-parser');
 const methodOverride = require('method-override');
 const app = express();
 app.use(bodyParser.json({
-  limit: '16mb'
+  limit: '32mb'
 }));
 app.use(methodOverride('X-HTTP-Method-Override'));
 const WorkerThread = require('./Thread');

--- a/server.js
+++ b/server.js
@@ -4,8 +4,10 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const methodOverride = require('method-override');
 const app = express();
+
+const maxRequestBodySize = process.env.MAX_REQUEST_BODY_SIZE || '16mb';
 app.use(bodyParser.json({
-  limit: '32mb'
+  limit: maxRequestBodySize
 }));
 app.use(methodOverride('X-HTTP-Method-Override'));
 const WorkerThread = require('./Thread');


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7534

## Description

We had a ([possibly arbitrary](https://github.com/formio/formio-workers/commit/ff78ad706a9236d1c19c9e63db366fb3d070745e)) body size limit in formio-workers, which was causing a SaaS customer to run into problems when processing a large-ish email template. This PR parameterizes the limit so that we can fine tune it without making code changes.

## Dependencies

n/a

## How has this PR been tested?

n/a

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [x] Any dependent changes have corresponding PRs that are listed above
