### PR TITLE
Change vm-utils to pull in 1.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "moment-timezone": "^0.5.35",
     "nunjucks": "^3.2.3",
     "nunjucks-date-filter": "^0.1.1",
-    "vm-utils": "https://github.com/formio/vm-utils.git#1.0.0"
+    "vm-utils": "https://github.com/formio/vm-utils.git#1.0.0-rc.1"
   },
   "devDependencies": {
     "claudia": "^5.14.0",


### PR DESCRIPTION
## Link to Jira Ticket

https://formio.atlassian.net/browse/FIO-7538

## Description

**What changed?**

vm-utils was pulling directly from main. Changes were made to main that caused the tests in formio OSS to start failing. This PR puts vm-utils back to a version prior to the changes that were made in main.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] My changes include tests that prove my fix is effective (or that my feature works as intended)
- [ ] New and existing unit/integration tests pass locally with my changes
- [ ] Any dependent changes have corresponding PRs that are listed above